### PR TITLE
Fix/book creation

### DIFF
--- a/src/main/java/br/com/solutis/livraria/controller/AuthorController.java
+++ b/src/main/java/br/com/solutis/livraria/controller/AuthorController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/author")
+@RequestMapping("/api/authors")
 @RequiredArgsConstructor
 @CrossOrigin
 public class AuthorController {

--- a/src/main/java/br/com/solutis/livraria/controller/BookController.java
+++ b/src/main/java/br/com/solutis/livraria/controller/BookController.java
@@ -2,7 +2,11 @@ package br.com.solutis.livraria.controller;
 
 import br.com.solutis.livraria.domain.EBook;
 import br.com.solutis.livraria.domain.PrintedBook;
+import br.com.solutis.livraria.repository.PublisherRepository;
+import br.com.solutis.livraria.requests.EBookPostRequestBody;
+import br.com.solutis.livraria.requests.PrintedBookPostRequestBody;
 import br.com.solutis.livraria.service.BookService;
+import br.com.solutis.livraria.service.PublisherService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,20 +14,40 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/book")
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
 @CrossOrigin
 public class BookController {
     private final BookService<EBook> eBookService;
     private final BookService<PrintedBook> printedBookService;
+    private final PublisherRepository publisherRepository;
 
     @PostMapping(path = "/printed")
-    public ResponseEntity<PrintedBook> addPrintedBook(@RequestBody @Valid PrintedBook printedBook) {
+    public ResponseEntity<PrintedBook> addPrintedBook(@RequestBody @Valid PrintedBookPostRequestBody printedBookPostRequestBody) {
+        PrintedBook printedBook = PrintedBook.builder()
+                .title(printedBookPostRequestBody.getTitle())
+                .price(printedBookPostRequestBody.getPrice())
+                .shipment(printedBookPostRequestBody.getShipment())
+                .stock(printedBookPostRequestBody.getStock())
+                .publisher(
+                        publisherRepository.findById(printedBookPostRequestBody.getPublisherId()).orElseThrow()
+                )
+                .build();
+
         return new ResponseEntity<>(printedBookService.addBook(printedBook), HttpStatus.CREATED);
     }
 
     @PostMapping(path = "/eletronic")
-    public ResponseEntity<EBook> addEbook(@RequestBody @Valid EBook eBook) {
+    public ResponseEntity<EBook> addEbook(@RequestBody @Valid EBookPostRequestBody eBookPostRequestBody) {
+        EBook eBook = EBook.builder()
+                .title(eBookPostRequestBody.getTitle())
+                .price(eBookPostRequestBody.getPrice())
+                .size(eBookPostRequestBody.getSize())
+                .publisher(
+                        publisherRepository.findById(eBookPostRequestBody.getPublisherId()).orElseThrow()
+                )
+                .build();
+
         return new ResponseEntity<>(eBookService.addBook(eBook), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/br/com/solutis/livraria/controller/PublisherController.java
+++ b/src/main/java/br/com/solutis/livraria/controller/PublisherController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/publisher")
+@RequestMapping("/api/publishers")
 @RequiredArgsConstructor
 @CrossOrigin
 public class PublisherController {

--- a/src/main/java/br/com/solutis/livraria/domain/Book.java
+++ b/src/main/java/br/com/solutis/livraria/domain/Book.java
@@ -1,5 +1,7 @@
 package br.com.solutis.livraria.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -33,6 +35,7 @@ public abstract class Book {
     @JoinColumn(name = "publisher_id", nullable = false)
     private Publisher publisher;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ManyToMany
     @JoinTable(
             name = "books_authors",
@@ -41,6 +44,7 @@ public abstract class Book {
     )
     private List<Author> authors;
 
+    @JsonIgnore
     @ManyToMany
     @JoinTable(
             name = "books_sales",

--- a/src/main/java/br/com/solutis/livraria/domain/Publisher.java
+++ b/src/main/java/br/com/solutis/livraria/domain/Publisher.java
@@ -1,5 +1,6 @@
 package br.com.solutis.livraria.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -25,6 +26,7 @@ public class Publisher {
     @Size(min = 3, message = "Name must be at least 3 characters long")
     private String name;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "publisher")
     private List<Book> books;
 

--- a/src/main/java/br/com/solutis/livraria/requests/EBookPostRequestBody.java
+++ b/src/main/java/br/com/solutis/livraria/requests/EBookPostRequestBody.java
@@ -1,0 +1,21 @@
+package br.com.solutis.livraria.requests;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class EBookPostRequestBody {
+    @NotNull(message = "Title is required")
+    @Size(min = 3, message = "Title must be at least 3 characters long")
+    private String title;
+
+    @NotNull(message = "Price is required")
+    private Float price;
+
+    @NotNull(message = "Size is required")
+    private Float size;
+
+    @NotNull(message = "Publisher id is required")
+    private Long publisherId;
+}

--- a/src/main/java/br/com/solutis/livraria/requests/PrintedBookPostRequestBody.java
+++ b/src/main/java/br/com/solutis/livraria/requests/PrintedBookPostRequestBody.java
@@ -1,0 +1,24 @@
+package br.com.solutis.livraria.requests;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PrintedBookPostRequestBody {
+    @NotNull(message = "Title is required")
+    @Size(min = 3, message = "Title must be at least 3 characters long")
+    private String title;
+
+    @NotNull(message = "Price is required")
+    private Float price;
+
+    @NotNull(message = "Shipment is required")
+    private Float shipment;
+
+    @NotNull(message = "Stock is required")
+    private Integer stock;
+
+    @NotNull(message = "Publisher id is required")
+    private Long publisherId;
+}


### PR DESCRIPTION
## Alterações

- Colocando os endpoints no padrão rest.
- Possibilitando a criação dos livros.

## Observações

- Antes não era possivel criar os livros, por que o id da publisher não era recebido. Esse pull request consertar isso, recebendo o id da publisher no body da requisição pra criar os livros e colocando a publisher no builder dos livros.
- Dentro de publisher coloquei @ JsonIgnore na lista de livros para evitar uma recursão.
- Dentro de book coloquei @ JsonInclude(JsonInclude.Include.NON_NULL) em autores e @ JsonIgnore em sales